### PR TITLE
Implement pausing brightness changes for specified time

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -96,6 +96,7 @@ pub fn apply_brightness(
     transition_mins: u32,
     location: Location,
     overrides: Vec<MonitorOverride>,
+    force_day_brightness: bool,
 ) -> ApplyResults {
     let overrides = overrides
         .iter()
@@ -132,9 +133,13 @@ pub fn apply_brightness(
 
             if let Some(BrightnessValues {
                 brightness_day,
-                brightness_night,
+                mut brightness_night,
             }) = monitor_values
             {
+                if force_day_brightness {
+                    brightness_night = brightness_day;
+                }
+
                 let brightness = calculate_brightness(
                     brightness_day,
                     brightness_night,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,7 @@ fn run(args: Args) -> anyhow::Result<()> {
             config.transition_mins,
             config.location.unwrap(),
             config.overrides,
+            false,
         );
         let pretty = serde_json::to_string_pretty(&result).unwrap();
         println!("{}", pretty);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -7,12 +7,15 @@ use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use sunrise_sunset_calculator::SunriseSunsetParameters;
 
 pub enum Message {
     Shutdown,
     Refresh(&'static str),
     Disable(&'static str),
     Enable(&'static str),
+    Unpause(&'static str),
+    Pause(&'static str, i64),
 }
 
 pub struct BrightnessController {
@@ -56,12 +59,23 @@ fn run<F: Fn()>(
 ) {
     log::info!("Starting BrightnessController");
     let mut enabled = true;
+    // When paused, this will be set to the SystemTime until which updates are paused.
+    let mut paused_until: Option<SystemTime> = None;
 
     loop {
+        // If we are paused, check whether the pause period has expired.
+        if let Some(pause_time) = paused_until {
+            if SystemTime::now() >= pause_time {
+                log::info!("BrightnessController pause period expired, resuming updates");
+                paused_until = None;
+            }
+        }
+
         let timeout = if enabled {
             // Apply brightness using latest config
             let config = config.read().unwrap().clone();
-            let result = apply(config);
+            let is_paused = paused_until.is_some();
+            let result = apply(config, is_paused);
             let timeout = calculate_timeout(&result);
 
             // Update last result
@@ -76,7 +90,7 @@ fn run<F: Fn()>(
         // Sleep until receiving message or timeout
         let rx_result = match timeout {
             None => {
-                log::info!("Brightness Worker sleeping indefinitely");
+                log::info!("BrightnessController sleeping indefinitely");
                 receiver.recv().map_err(|e| e.into())
             }
             Some(timeout) => {
@@ -97,7 +111,7 @@ fn run<F: Fn()>(
                 break;
             }
             Ok(Message::Refresh(src)) => {
-                log::info!("Refreshing due to '{src}'");
+                log::info!("Refreshing BrightnessController due to '{src}'");
             }
             Ok(Message::Disable(src)) => {
                 log::info!("Disabling BrightnessController due to '{src}'");
@@ -107,8 +121,22 @@ fn run<F: Fn()>(
                 log::info!("Enabling BrightnessController due to '{src}'");
                 enabled = true;
             }
+            Ok(Message::Unpause(src)) => {
+                log::info!("Unpausing BrightnessController due to '{src}'");
+                paused_until = None;
+            }
+            Ok(Message::Pause(src, time)) => {
+                log::info!("Pausing BrightnessController due to '{src}' for '{time}' seconds");
+                let pause_time = if time < 0 {
+                    let config = config.read().unwrap().clone();
+                    compute_next_sunrise(config)
+                } else {
+                    SystemTime::now() + Duration::from_secs(time as u64)
+                };
+                paused_until = Some(pause_time);
+            }
             Err(RecvTimeoutError::Timeout) => {
-                log::debug!("Refreshing due to timeout")
+                log::debug!("Refreshing BrightnessController due to timeout")
             }
             Err(RecvTimeoutError::Disconnected) => panic!("Unexpected disconnection"),
         }
@@ -131,7 +159,7 @@ fn calculate_timeout(results: &Option<ApplyResults>) -> Option<SystemTime> {
 }
 
 // Calculate and apply the brightness
-fn apply(config: SsbConfig) -> Option<ApplyResults> {
+fn apply(config: SsbConfig, force_day_brightness: bool) -> Option<ApplyResults> {
     if let Some(location) = config.location {
         Some(apply_brightness(
             config.brightness_day,
@@ -139,9 +167,39 @@ fn apply(config: SsbConfig) -> Option<ApplyResults> {
             config.transition_mins,
             location,
             config.overrides,
+            force_day_brightness,
         ))
     } else {
         log::warn!("Skipping apply because no location is configured");
         None
+    }
+}
+
+// Calculate the next sunrise time
+fn compute_next_sunrise(config: SsbConfig) -> SystemTime {
+    if let Some(location) = config.location {
+        let epoch_time_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let sun =
+            SunriseSunsetParameters::new(epoch_time_now, location.latitude, location.longitude)
+                .calculate()
+                .unwrap();
+
+        // If the calculated sunrise is in the past, calculate tomorrow's sunrise.
+        if sun.rise <= epoch_time_now {
+            let tomorrow = epoch_time_now + 86400;
+            let sun_tomorrow =
+                SunriseSunsetParameters::new(tomorrow, location.latitude, location.longitude)
+                    .calculate()
+                    .unwrap();
+            UNIX_EPOCH + Duration::from_secs(sun_tomorrow.rise as u64)
+        } else {
+            UNIX_EPOCH + Duration::from_secs(sun.rise as u64)
+        }
+    } else {
+        log::warn!("Assuming next sunrise is in 12 hours because no location is configured");
+        SystemTime::now() + Duration::from_secs(43200)
     }
 }

--- a/src/gui/brightness_settings.rs
+++ b/src/gui/brightness_settings.rs
@@ -94,7 +94,11 @@ impl Page for BrightnessSettingsPage {
                 self.copy_to_config(&mut config);
                 app_state
                     .controller
-                    .send(Message::Refresh("Brightness change"))
+                    .send(Message::Unpause("UI Apply"))
+                    .unwrap();
+                app_state
+                    .controller
+                    .send(Message::Refresh("UI Apply"))
                     .unwrap();
             }
             if ui.button("Save").clicked() {
@@ -102,7 +106,7 @@ impl Page for BrightnessSettingsPage {
                 self.copy_to_config(&mut config);
                 app_state
                     .controller
-                    .send(Message::Refresh("Brightness change"))
+                    .send(Message::Refresh("UI Save"))
                     .unwrap();
                 save_config(&mut config, &app_state.transitions);
             };

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,6 +6,7 @@ mod monitor_overrides;
 mod status;
 
 use crate::common::APP_NAME;
+use crate::controller::Message;
 use crate::gui::app::SsbEguiApp;
 use crate::tray::read_icon;
 use egui_wgpu::wgpu::PowerPreference;
@@ -13,6 +14,7 @@ use egui_winit::winit;
 use egui_winit::winit::event::{Event, WindowEvent};
 use egui_winit::winit::event_loop::{EventLoopProxy, EventLoopWindowTarget};
 use egui_winit::winit::window::Icon;
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -33,6 +35,9 @@ pub enum NextPaint {
 pub enum UserEvent {
     // When the tray button is clicked - we should open or bring forward the window
     OpenWindow(&'static str),
+    // When the tray button for a pause is clicked - it should pause changing brightness for the given duration.
+    // When the duration is negative, it will be paused until sunrise.
+    Pause(&'static str, i64),
     // When the tray exit button is clicked - the application should exit
     Exit(&'static str),
     // Hide the window if it is open
@@ -66,6 +71,7 @@ impl Drop for WgpuWinitRunning {
 pub struct WgpuWinitApp<F> {
     repaint_proxy: EventLoopProxy<UserEvent>,
     running: Option<WgpuWinitRunning>,
+    controller: Sender<Message>,
     icon: Icon,
     app_factory: F,
     start_minimised: bool,
@@ -75,6 +81,7 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
     pub fn new(
         event_loop: EventLoopProxy<UserEvent>,
         start_minimised: bool,
+        controller: Sender<Message>,
         app_factory: F,
     ) -> Self {
         if start_minimised {
@@ -85,6 +92,7 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
         Self {
             repaint_proxy: event_loop,
             running: None,
+            controller,
             icon,
             app_factory,
             start_minimised,
@@ -254,6 +262,14 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
                 } else {
                     self.launch_window(event_loop)
                 }
+            }
+
+            Event::UserEvent(UserEvent::Pause(src, time)) => {
+                log::info!("Received Pause action from '{src}' for '{time}' seconds");
+                self.controller
+                    .send(Message::Pause(src, time.clone()))
+                    .unwrap();
+                NextPaint::Wait
             }
 
             Event::UserEvent(UserEvent::RequestRepaint { when, frame_nr }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,14 +80,19 @@ fn main() {
     let _tray = tray::create(&event_loop);
 
     let app_proxy = event_loop.create_proxy();
-    let mut framework = WgpuWinitApp::new(event_loop.create_proxy(), args.minimised, move || {
-        SsbEguiApp::new(
-            app_proxy.clone(),
-            controller.last_result.clone(),
-            config.clone(),
-            controller.sender.clone(),
-        )
-    });
+    let mut framework = WgpuWinitApp::new(
+        event_loop.create_proxy(),
+        args.minimised,
+        controller.sender.clone(),
+        move || {
+            SsbEguiApp::new(
+                app_proxy.clone(),
+                controller.last_result.clone(),
+                config.clone(),
+                controller.sender.clone(),
+            )
+        },
+    );
 
     let mut next_repaint_time = Some(Instant::now());
 

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -2,11 +2,17 @@ use crate::common::APP_NAME;
 use crate::gui::UserEvent;
 use egui_winit::winit::event_loop::{EventLoop, EventLoopProxy};
 use std::sync::{Arc, Mutex};
-use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItemBuilder};
+use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItemBuilder, SubmenuBuilder};
 use tray_icon::{ClickType, Icon, TrayIcon, TrayIconBuilder, TrayIconEvent};
 
 const MENU_ID_OPEN: &str = "OPEN";
 const MENU_ID_EXIT: &str = "EXIT";
+//const MENU_ID_UNPAUSE: &str = "UNPAUSE"; // TODO: Add unpause when paused
+const MENU_ID_PAUSE_15M: &str = "PAUSE_15M";
+const MENU_ID_PAUSE_30M: &str = "PAUSE_30M";
+const MENU_ID_PAUSE_1H: &str = "PAUSE_1H";
+const MENU_ID_PAUSE_2H: &str = "PAUSE_2H";
+const MENU_ID_PAUSE_SUNRISE: &str = "PAUSE_SUNRISE";
 
 pub fn read_icon() -> (Vec<u8>, png::OutputInfo) {
     let mut decoder = png::Decoder::new(include_bytes!("../assets/icon-256.png").as_slice());
@@ -44,6 +50,38 @@ fn create_internal(event_loop: EventLoopProxy<UserEvent>) -> TrayIcon {
             .id(MenuId::new(MENU_ID_OPEN))
             .enabled(true)
             .build(),
+        &SubmenuBuilder::new()
+            .text("Pause for…")
+            .enabled(true)
+            .items(&[
+                &MenuItemBuilder::new()
+                    .text("Until next sunrise")
+                    .id(MenuId::new(MENU_ID_PAUSE_SUNRISE))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("15 minutes")
+                    .id(MenuId::new(MENU_ID_PAUSE_15M))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("30 minutes")
+                    .id(MenuId::new(MENU_ID_PAUSE_30M))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("1 hour")
+                    .id(MenuId::new(MENU_ID_PAUSE_1H))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("2 hours")
+                    .id(MenuId::new(MENU_ID_PAUSE_2H))
+                    .enabled(true)
+                    .build(),
+            ])
+            .build()
+            .unwrap(),
         &MenuItemBuilder::new()
             .text("Exit")
             .id(MenuId::new(MENU_ID_EXIT))
@@ -76,6 +114,11 @@ fn create_internal(event_loop: EventLoopProxy<UserEvent>) -> TrayIcon {
         let action = match event.id.0.as_str() {
             MENU_ID_OPEN => UserEvent::OpenWindow("Tray Button"),
             MENU_ID_EXIT => UserEvent::Exit("Tray Button"),
+            MENU_ID_PAUSE_15M => UserEvent::Pause("Tray Button", 900),
+            MENU_ID_PAUSE_30M => UserEvent::Pause("Tray Button", 1800),
+            MENU_ID_PAUSE_1H => UserEvent::Pause("Tray Button", 3600),
+            MENU_ID_PAUSE_2H => UserEvent::Pause("Tray Button", 7200),
+            MENU_ID_PAUSE_SUNRISE => UserEvent::Pause("Tray Button", -1),
             _ => return,
         };
         menu_loop.lock().unwrap().send_event(action).unwrap();


### PR DESCRIPTION
Fixes #46

![image](https://github.com/user-attachments/assets/e85d9ef7-50b2-4f62-9091-bd255b695c45)

I think I got the logic right, but a second pair of eyes would definitely help review this. When pressing apply in the UI, it will unpause. Ideally would also need to add a conditional unpause button in the tray, if it is currently paused.

Some users would probably prefer custom pause times, but I don't want to add configuration for that atm.