### PR TITLE
Prototype detecting fullscreen apps to override brightness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ console = "0.15.7"
 version = "0.52.0"
 features = [
     "Win32_Foundation",
+    "Win32_UI_Accessibility",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_LibraryLoader",
     "Win32_Graphics_Gdi",

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -3,7 +3,7 @@ use crate::config::{BrightnessValues, Location, MonitorOverride, MonitorProperty
 use brightness::blocking::{Brightness, BrightnessDevice};
 use itertools::Itertools;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 use sunrise_sunset_calculator::SunriseSunsetParameters;
 use wildmatch::WildMatch;
@@ -97,6 +97,7 @@ pub fn apply_brightness(
     location: Location,
     overrides: Vec<MonitorOverride>,
     force_day_brightness: bool,
+    fullscreen_overrides: Option<HashSet<String>>,
 ) -> ApplyResults {
     let overrides = overrides
         .iter()
@@ -131,12 +132,23 @@ pub fn apply_brightness(
                 Some(o) => o.brightness,
             };
 
+            // TODO: Maybe get full display names with EnumDisplayDevicesW in windows.rs?
+            // TODO: Add a setting to control this
+            let force_day_brightness_for_this_monitor = force_day_brightness
+                || if let Some(fullscreen_overrides) = &fullscreen_overrides {
+                    fullscreen_overrides
+                        .iter()
+                        .any(|pattern| properties.device_name.starts_with(pattern))
+                } else {
+                    false
+                };
+
             if let Some(BrightnessValues {
                 brightness_day,
                 mut brightness_night,
             }) = monitor_values
             {
-                if force_day_brightness {
+                if force_day_brightness_for_this_monitor {
                     brightness_night = brightness_day;
                 }
 

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -96,6 +96,7 @@ pub fn apply_brightness(
     transition_mins: u32,
     location: Location,
     overrides: Vec<MonitorOverride>,
+    force_day_brightness: bool,
 ) -> ApplyResults {
     let overrides = overrides
         .iter()
@@ -132,9 +133,13 @@ pub fn apply_brightness(
 
             if let Some(BrightnessValues {
                 brightness_day,
-                brightness_night,
+                mut brightness_night,
             }) = monitor_values
             {
+                if force_day_brightness {
+                    brightness_night = brightness_day;
+                }
+
                 let brightness = calculate_brightness(
                     brightness_day,
                     brightness_night,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,7 @@ fn run(args: Args) -> anyhow::Result<()> {
             config.transition_mins,
             config.location.unwrap(),
             config.overrides,
+            false,
         );
         let pretty = serde_json::to_string_pretty(&result).unwrap();
         println!("{}", pretty);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,7 @@ fn run(args: Args) -> anyhow::Result<()> {
             config.location.unwrap(),
             config.overrides,
             false,
+            None,
         );
         let pretty = serde_json::to_string_pretty(&result).unwrap();
         println!("{}", pretty);

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -7,12 +7,15 @@ use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use sunrise_sunset_calculator::SunriseSunsetParameters;
 
 pub enum Message {
     Shutdown,
     Refresh(&'static str),
     Disable(&'static str),
     Enable(&'static str),
+    Unpause(&'static str),
+    Pause(&'static str, i64),
 }
 
 pub struct BrightnessController {
@@ -56,12 +59,23 @@ fn run<F: Fn()>(
 ) {
     log::info!("Starting BrightnessController");
     let mut enabled = true;
+    // When paused, this will be set to the SystemTime until which updates are paused.
+    let mut paused_until: Option<SystemTime> = None;
 
     loop {
+        // If we are paused, check whether the pause period has expired.
+        if let Some(pause_time) = paused_until {
+            if SystemTime::now() >= pause_time {
+                log::info!("BrightnessController pause period expired, resuming updates");
+                paused_until = None;
+            }
+        }
+
         let timeout = if enabled {
             // Apply brightness using latest config
             let config = config.read().unwrap().clone();
-            let result = apply(config);
+            let is_paused = paused_until.is_some();
+            let result = apply(config, is_paused);
             let timeout = calculate_timeout(&result);
 
             // Update last result
@@ -76,7 +90,7 @@ fn run<F: Fn()>(
         // Sleep until receiving message or timeout
         let rx_result = match timeout {
             None => {
-                log::info!("Brightness Worker sleeping indefinitely");
+                log::info!("BrightnessController sleeping indefinitely");
                 receiver.recv().map_err(|e| e.into())
             }
             Some(timeout) => {
@@ -97,7 +111,7 @@ fn run<F: Fn()>(
                 break;
             }
             Ok(Message::Refresh(src)) => {
-                log::info!("Refreshing due to '{src}'");
+                log::info!("Refreshing BrightnessController due to '{src}'");
             }
             Ok(Message::Disable(src)) => {
                 log::info!("Disabling BrightnessController due to '{src}'");
@@ -107,8 +121,22 @@ fn run<F: Fn()>(
                 log::info!("Enabling BrightnessController due to '{src}'");
                 enabled = true;
             }
+            Ok(Message::Unpause(src)) => {
+                log::info!("Unpausing BrightnessController due to '{src}'");
+                paused_until = None;
+            }
+            Ok(Message::Pause(src, time)) => {
+                log::info!("Pausing BrightnessController due to '{src}' for '{time}' seconds");
+                let pause_time = if time < 0 {
+                    let config = config.read().unwrap().clone();
+                    compute_next_sunrise(config)
+                } else {
+                    SystemTime::now() + Duration::from_secs(time as u64)
+                };
+                paused_until = Some(pause_time);
+            }
             Err(RecvTimeoutError::Timeout) => {
-                log::debug!("Refreshing due to timeout")
+                log::debug!("Refreshing BrightnessController due to timeout")
             }
             Err(RecvTimeoutError::Disconnected) => panic!("Unexpected disconnection"),
         }
@@ -131,7 +159,7 @@ fn calculate_timeout(results: &Option<ApplyResults>) -> Option<SystemTime> {
 }
 
 // Calculate and apply the brightness
-fn apply(config: SsbConfig) -> Option<ApplyResults> {
+fn apply(config: SsbConfig, force_day_brightness: bool) -> Option<ApplyResults> {
     if let Some(location) = config.location {
         Some(apply_brightness(
             config.brightness_day,
@@ -139,9 +167,39 @@ fn apply(config: SsbConfig) -> Option<ApplyResults> {
             config.transition_mins,
             location,
             config.overrides,
+            force_day_brightness,
         ))
     } else {
         log::warn!("Skipping apply because no location is configured");
         None
+    }
+}
+
+// Calculate the next sunrise time
+fn compute_next_sunrise(config: SsbConfig) -> SystemTime {
+    if let Some(location) = config.location {
+        let epoch_time_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let sun =
+            SunriseSunsetParameters::new(epoch_time_now, location.latitude, location.longitude)
+                .calculate()
+                .unwrap();
+
+        // If the calculated sunrise is in the past, calculate tomorrow's sunrise.
+        if sun.rise <= epoch_time_now {
+            let tomorrow = epoch_time_now + 86400;
+            let sun_tomorrow =
+                SunriseSunsetParameters::new(tomorrow, location.latitude, location.longitude)
+                    .calculate()
+                    .unwrap();
+            UNIX_EPOCH + Duration::from_secs(sun_tomorrow.rise as u64)
+        } else {
+            UNIX_EPOCH + Duration::from_secs(sun.rise as u64)
+        }
+    } else {
+        log::warn!("Assuming next sunrise is in 12 hours because no location is configured");
+        SystemTime::now() + Duration::from_secs(43200)
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,6 +1,7 @@
 use crate::apply::{apply_brightness, ApplyResults};
 use crate::config::SsbConfig;
 use human_repr::HumanDuration;
+use std::collections::HashSet;
 use std::mem::take;
 use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{mpsc, Arc, RwLock};
@@ -16,6 +17,8 @@ pub enum Message {
     Enable(&'static str),
     Unpause(&'static str),
     Pause(&'static str, i64),
+    FullscreenAdd(String),
+    FullscreenRemove(String),
 }
 
 pub struct BrightnessController {
@@ -61,6 +64,7 @@ fn run<F: Fn()>(
     let mut enabled = true;
     // When paused, this will be set to the SystemTime until which updates are paused.
     let mut paused_until: Option<SystemTime> = None;
+    let mut fullscreen_overrides: HashSet<String> = HashSet::new();
 
     loop {
         // If we are paused, check whether the pause period has expired.
@@ -75,7 +79,7 @@ fn run<F: Fn()>(
             // Apply brightness using latest config
             let config = config.read().unwrap().clone();
             let is_paused = paused_until.is_some();
-            let result = apply(config, is_paused);
+            let result = apply(config, is_paused, fullscreen_overrides.clone());
             let timeout = calculate_timeout(&result);
 
             // Update last result
@@ -135,6 +139,14 @@ fn run<F: Fn()>(
                 };
                 paused_until = Some(pause_time);
             }
+            Ok(Message::FullscreenAdd(id)) => {
+                log::info!("Adding monitor {id} to fullscreen override");
+                fullscreen_overrides.insert(id);
+            }
+            Ok(Message::FullscreenRemove(id)) => {
+                log::info!("Removing monitor {id} from fullscreen override");
+                fullscreen_overrides.remove(&id);
+            }
             Err(RecvTimeoutError::Timeout) => {
                 log::debug!("Refreshing BrightnessController due to timeout")
             }
@@ -159,7 +171,11 @@ fn calculate_timeout(results: &Option<ApplyResults>) -> Option<SystemTime> {
 }
 
 // Calculate and apply the brightness
-fn apply(config: SsbConfig, force_day_brightness: bool) -> Option<ApplyResults> {
+fn apply(
+    config: SsbConfig,
+    force_day_brightness: bool,
+    fullscreen_overrides: HashSet<String>,
+) -> Option<ApplyResults> {
     if let Some(location) = config.location {
         Some(apply_brightness(
             config.brightness_day,
@@ -168,6 +184,7 @@ fn apply(config: SsbConfig, force_day_brightness: bool) -> Option<ApplyResults> 
             location,
             config.overrides,
             force_day_brightness,
+            Some(fullscreen_overrides),
         ))
     } else {
         log::warn!("Skipping apply because no location is configured");

--- a/src/event_watcher/windows.rs
+++ b/src/event_watcher/windows.rs
@@ -1,20 +1,31 @@
 use crate::controller::{BrightnessController, Message};
 use crate::gui::UserEvent;
 use egui_winit::winit::event_loop::{EventLoop, EventLoopProxy};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::mpsc;
 use std::sync::mpsc::sync_channel;
 use std::thread::JoinHandle;
 use win32_utils::error::{check_error, CheckError};
-use win32_utils::window::WindowDataExtension;
 use windows::core::{w, PCWSTR};
-use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
-use windows::Win32::System::LibraryLoader::GetModuleHandleW;
-use windows::Win32::System::RemoteDesktop::WTSRegisterSessionNotification;
-use windows::Win32::UI::WindowsAndMessaging::{
-    CreateWindowExW, DefWindowProcA, DispatchMessageW, GetMessageW, PostQuitMessage,
-    RegisterClassW, RegisterWindowMessageW, SendMessageW, SetWindowLongPtrW, CW_USEDEFAULT,
-    GWLP_USERDATA, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WM_APP, WM_DISPLAYCHANGE,
-    WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_SESSION_LOCK, WTS_SESSION_UNLOCK,
+use windows::Win32::Graphics::Gdi::MONITORINFOEXW;
+use windows::Win32::{
+    Foundation::{HWND, LPARAM, LRESULT, RECT, WPARAM},
+    Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromWindow, HMONITOR, MONITORINFO, MONITOR_DEFAULTTONULL,
+    },
+    System::{LibraryLoader::GetModuleHandleW, RemoteDesktop::WTSRegisterSessionNotification},
+    UI::{
+        Accessibility::{SetWinEventHook, UnhookWinEvent, HWINEVENTHOOK},
+        WindowsAndMessaging::{
+            CreateWindowExW, DefWindowProcA, DispatchMessageW, GetMessageW, GetWindowRect,
+            PostQuitMessage, RegisterClassW, RegisterWindowMessageW, SendMessageW, CW_USEDEFAULT,
+            EVENT_SYSTEM_FOREGROUND, MSG, WINDOW_EX_STYLE, WINDOW_STYLE, WINEVENT_OUTOFCONTEXT,
+            WM_APP, WM_DISPLAYCHANGE, WM_WTSSESSION_CHANGE, WNDCLASSW, WTS_SESSION_LOCK,
+            WTS_SESSION_UNLOCK,
+        },
+    },
 };
 
 const EXIT_LOOP: u32 = WM_APP + 999;
@@ -23,6 +34,8 @@ pub struct EventWatcher {
     thread: Option<JoinHandle<()>>,
     hwnd: HWND,
 }
+
+static GLOBAL_WINDOW_DATA: AtomicPtr<WindowData> = AtomicPtr::new(std::ptr::null_mut());
 
 impl EventWatcher {
     pub fn start(
@@ -34,11 +47,14 @@ impl EventWatcher {
         let (tx, rx) = sync_channel(0);
 
         let thread = std::thread::spawn(move || {
-            let mut window_data = Box::new(WindowData {
+            let window_data = Box::new(WindowData {
                 sender: brightness_sender,
                 open_window_msg_code: register_open_window_message(),
                 main_loop: proxy,
+                is_foreground_window_fullscreen: false,
             });
+
+            GLOBAL_WINDOW_DATA.store(Box::into_raw(window_data), Ordering::SeqCst);
 
             unsafe {
                 // Create Window Class
@@ -69,21 +85,29 @@ impl EventWatcher {
                 .check_error()
                 .unwrap();
 
-                // Register Window data
-                check_error(|| {
-                    SetWindowLongPtrW(hwnd, GWLP_USERDATA, window_data.as_mut() as *mut _ as isize)
-                })
-                .unwrap();
-
                 tx.send(hwnd).unwrap();
 
                 // Register for Session Notifications
                 WTSRegisterSessionNotification(hwnd, 0).unwrap();
 
+                // Register for foreground window change event
+                // TODO: Maybe also need to listen for EVENT_OBJECT_LOCATIONCHANGE
+                let hook_handle: HWINEVENTHOOK = SetWinEventHook(
+                    EVENT_SYSTEM_FOREGROUND,
+                    EVENT_SYSTEM_FOREGROUND,
+                    None,
+                    Some(win_event_hook_proc),
+                    0,
+                    0,
+                    WINEVENT_OUTOFCONTEXT,
+                );
+
                 let mut message = MSG::default();
                 while GetMessageW(&mut message, None, 0, 0).into() {
                     DispatchMessageW(&message);
                 }
+
+                UnhookWinEvent(hook_handle);
             }
             log::debug!("EventWatcher thread exiting");
         });
@@ -108,6 +132,7 @@ struct WindowData {
     sender: mpsc::Sender<Message>,
     open_window_msg_code: u32,
     main_loop: Option<EventLoopProxy<UserEvent>>,
+    is_foreground_window_fullscreen: bool,
 }
 
 unsafe extern "system" fn wndproc(
@@ -116,7 +141,10 @@ unsafe extern "system" fn wndproc(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    if let Some(window_data) = window.get_user_data::<WindowData>() {
+    let window_data_ptr = GLOBAL_WINDOW_DATA.load(Ordering::SeqCst);
+    if !window_data_ptr.is_null() {
+        let window_data = &mut *window_data_ptr;
+
         match message {
             WM_DISPLAYCHANGE => {
                 log::info!("Detected possible display change (WM_DISPLAYCHANGE)");
@@ -160,8 +188,83 @@ unsafe extern "system" fn wndproc(
     DefWindowProcA(window, message, wparam, lparam)
 }
 
+unsafe extern "system" fn win_event_hook_proc(
+    _h_win_event_hook: HWINEVENTHOOK,
+    _event: u32,
+    hwnd: HWND,
+    _id_object: i32,
+    _id_child: i32,
+    _id_event_thread: u32,
+    _dwms_event_time: u32,
+) {
+    let mut window_rect = RECT::default();
+    if !GetWindowRect(hwnd, &mut window_rect).is_ok() {
+        return;
+    }
+
+    let hmonitor: HMONITOR = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
+    if hmonitor.is_invalid() {
+        return;
+    }
+
+    let mut info = MONITORINFOEXW::default();
+    info.monitorInfo.cbSize = size_of::<MONITORINFOEXW>() as u32;
+    let info_ptr = &mut info as *mut _ as *mut MONITORINFO;
+
+    if !GetMonitorInfoW(hmonitor, info_ptr).as_bool() {
+        return;
+    }
+
+    let is_fullscreen = window_rect.left == info.monitorInfo.rcMonitor.left
+        && window_rect.top == info.monitorInfo.rcMonitor.top
+        && window_rect.right == info.monitorInfo.rcMonitor.right
+        && window_rect.bottom == info.monitorInfo.rcMonitor.bottom;
+
+    // TODO: EnumDisplayDevicesW to get the actual device paths?
+    let display_name = wchar_to_string(&info.szDevice);
+
+    let window_data_ptr = GLOBAL_WINDOW_DATA.load(Ordering::SeqCst);
+    if window_data_ptr.is_null() {
+        return;
+    }
+
+    let window_data = &mut *window_data_ptr;
+
+    // TODO: This is likely to be buggy on multi monitor setups when both monitors have fullscreen apps open
+    if window_data.is_foreground_window_fullscreen == is_fullscreen {
+        return;
+    }
+
+    log::debug!(
+        "Fullscreen: {} -> {} on '{}'",
+        window_data.is_foreground_window_fullscreen,
+        is_fullscreen,
+        display_name
+    );
+
+    window_data.is_foreground_window_fullscreen = is_fullscreen;
+
+    if is_fullscreen {
+        window_data
+            .sender
+            .send(Message::FullscreenAdd(display_name))
+            .unwrap();
+    } else {
+        window_data
+            .sender
+            .send(Message::FullscreenRemove(display_name))
+            .unwrap();
+    }
+}
+
 pub fn register_open_window_message() -> u32 {
     unsafe {
         check_error(|| RegisterWindowMessageW(w!("solar-screen-brightness.open_window"))).unwrap()
     }
+}
+
+fn wchar_to_string(s: &[u16]) -> String {
+    let end = s.iter().position(|&x| x == 0).unwrap_or(s.len());
+    let truncated = &s[0..end];
+    OsString::from_wide(truncated).to_string_lossy().into()
 }

--- a/src/gui/brightness_settings.rs
+++ b/src/gui/brightness_settings.rs
@@ -94,7 +94,11 @@ impl Page for BrightnessSettingsPage {
                 self.copy_to_config(&mut config);
                 app_state
                     .controller
-                    .send(Message::Refresh("Brightness change"))
+                    .send(Message::Unpause("UI Apply"))
+                    .unwrap();
+                app_state
+                    .controller
+                    .send(Message::Refresh("UI Apply"))
                     .unwrap();
             }
             if ui.button("Save").clicked() {
@@ -102,7 +106,7 @@ impl Page for BrightnessSettingsPage {
                 self.copy_to_config(&mut config);
                 app_state
                     .controller
-                    .send(Message::Refresh("Brightness change"))
+                    .send(Message::Refresh("UI Save"))
                     .unwrap();
                 save_config(&mut config, &app_state.transitions);
             };

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,6 +6,7 @@ mod monitor_overrides;
 mod status;
 
 use crate::common::APP_NAME;
+use crate::controller::Message;
 use crate::gui::app::SsbEguiApp;
 use crate::tray::read_icon;
 use egui_wgpu::wgpu::PowerPreference;
@@ -13,6 +14,7 @@ use egui_winit::winit;
 use egui_winit::winit::event::{Event, WindowEvent};
 use egui_winit::winit::event_loop::{EventLoopProxy, EventLoopWindowTarget};
 use egui_winit::winit::window::Icon;
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -33,6 +35,9 @@ pub enum NextPaint {
 pub enum UserEvent {
     // When the tray button is clicked - we should open or bring forward the window
     OpenWindow(&'static str),
+    // When the tray button for a pause is clicked - it should pause changing brightness for the given duration.
+    // When the duration is negative, it will be paused until sunrise.
+    Pause(&'static str, i64),
     // When the tray exit button is clicked - the application should exit
     Exit(&'static str),
     // Hide the window if it is open
@@ -66,6 +71,7 @@ impl Drop for WgpuWinitRunning {
 pub struct WgpuWinitApp<F> {
     repaint_proxy: EventLoopProxy<UserEvent>,
     running: Option<WgpuWinitRunning>,
+    controller: Sender<Message>,
     icon: Icon,
     app_factory: F,
     start_minimised: bool,
@@ -75,6 +81,7 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
     pub fn new(
         event_loop: EventLoopProxy<UserEvent>,
         start_minimised: bool,
+        controller: Sender<Message>,
         app_factory: F,
     ) -> Self {
         if start_minimised {
@@ -85,6 +92,7 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
         Self {
             repaint_proxy: event_loop,
             running: None,
+            controller,
             icon,
             app_factory,
             start_minimised,
@@ -254,6 +262,14 @@ impl<F: Fn() -> SsbEguiApp> WgpuWinitApp<F> {
                 } else {
                     self.launch_window(event_loop)
                 }
+            }
+
+            Event::UserEvent(UserEvent::Pause(src, time)) => {
+                log::info!("Received Pause action from '{src}' for '{time}' seconds");
+                self.controller
+                    .send(Message::Pause(src, time.clone()))
+                    .unwrap();
+                NextPaint::Wait
             }
 
             Event::UserEvent(UserEvent::RequestRepaint { when, frame_nr }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,14 +80,19 @@ fn main() {
     let _tray = tray::create(&event_loop);
 
     let app_proxy = event_loop.create_proxy();
-    let mut framework = WgpuWinitApp::new(event_loop.create_proxy(), args.minimised, move || {
-        SsbEguiApp::new(
-            app_proxy.clone(),
-            controller.last_result.clone(),
-            config.clone(),
-            controller.sender.clone(),
-        )
-    });
+    let mut framework = WgpuWinitApp::new(
+        event_loop.create_proxy(),
+        args.minimised,
+        controller.sender.clone(),
+        move || {
+            SsbEguiApp::new(
+                app_proxy.clone(),
+                controller.last_result.clone(),
+                config.clone(),
+                controller.sender.clone(),
+            )
+        },
+    );
 
     let mut next_repaint_time = Some(Instant::now());
 

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -2,11 +2,17 @@ use crate::common::APP_NAME;
 use crate::gui::UserEvent;
 use egui_winit::winit::event_loop::{EventLoop, EventLoopProxy};
 use std::sync::{Arc, Mutex};
-use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItemBuilder};
+use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItemBuilder, SubmenuBuilder};
 use tray_icon::{ClickType, Icon, TrayIcon, TrayIconBuilder, TrayIconEvent};
 
 const MENU_ID_OPEN: &str = "OPEN";
 const MENU_ID_EXIT: &str = "EXIT";
+//const MENU_ID_UNPAUSE: &str = "UNPAUSE"; // TODO: Add unpause when paused
+const MENU_ID_PAUSE_15M: &str = "PAUSE_15M";
+const MENU_ID_PAUSE_30M: &str = "PAUSE_30M";
+const MENU_ID_PAUSE_1H: &str = "PAUSE_1H";
+const MENU_ID_PAUSE_2H: &str = "PAUSE_2H";
+const MENU_ID_PAUSE_SUNRISE: &str = "PAUSE_SUNRISE";
 
 pub fn read_icon() -> (Vec<u8>, png::OutputInfo) {
     let mut decoder = png::Decoder::new(include_bytes!("../assets/icon-256.png").as_slice());
@@ -44,6 +50,38 @@ fn create_internal(event_loop: EventLoopProxy<UserEvent>) -> TrayIcon {
             .id(MenuId::new(MENU_ID_OPEN))
             .enabled(true)
             .build(),
+        &SubmenuBuilder::new()
+            .text("Pause for…")
+            .enabled(true)
+            .items(&[
+                &MenuItemBuilder::new()
+                    .text("Until next sunrise")
+                    .id(MenuId::new(MENU_ID_PAUSE_SUNRISE))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("15 minutes")
+                    .id(MenuId::new(MENU_ID_PAUSE_15M))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("30 minutes")
+                    .id(MenuId::new(MENU_ID_PAUSE_30M))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("1 hour")
+                    .id(MenuId::new(MENU_ID_PAUSE_1H))
+                    .enabled(true)
+                    .build(),
+                &MenuItemBuilder::new()
+                    .text("2 hours")
+                    .id(MenuId::new(MENU_ID_PAUSE_2H))
+                    .enabled(true)
+                    .build(),
+            ])
+            .build()
+            .unwrap(),
         &MenuItemBuilder::new()
             .text("Exit")
             .id(MenuId::new(MENU_ID_EXIT))
@@ -76,6 +114,11 @@ fn create_internal(event_loop: EventLoopProxy<UserEvent>) -> TrayIcon {
         let action = match event.id.0.as_str() {
             MENU_ID_OPEN => UserEvent::OpenWindow("Tray Button"),
             MENU_ID_EXIT => UserEvent::Exit("Tray Button"),
+            MENU_ID_PAUSE_15M => UserEvent::Pause("Tray Button", 900),
+            MENU_ID_PAUSE_30M => UserEvent::Pause("Tray Button", 1800),
+            MENU_ID_PAUSE_1H => UserEvent::Pause("Tray Button", 3600),
+            MENU_ID_PAUSE_2H => UserEvent::Pause("Tray Button", 7200),
+            MENU_ID_PAUSE_SUNRISE => UserEvent::Pause("Tray Button", -1),
             _ => return,
         };
         menu_loop.lock().unwrap().send_event(action).unwrap();


### PR DESCRIPTION
Depends on #47.

I prototyped the code to detect fullscreen foreground windows on Windows systems.

This appears to work on my machine with two screens, whenever switching to an app that is fullscreened on either screen. When switching to another non-fullscreen window, it drops brightness.

I'm calling this a prototype, because it currently just calls "pause" which forces day brightness on all monitors, but for this feature I'd want it to only change brightness of the monitor that has the fullscreen window. It probably also needs a setting for users to disable this feature, and maybe set custom brightness.

For only changing brightness of one screen, I am unsure how to implement this well. One day I had in mind is just get the device id/path and create an override similar to how you can do that in GUI.
